### PR TITLE
Improve bias char input behavior

### DIFF
--- a/src/app/generator/generator.component.spec.ts
+++ b/src/app/generator/generator.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { GeneratorPageComponent } from './generator.component';
+import { ApiService } from '../api.service';
+import { of } from 'rxjs';
+
+class MockApiService {
+  getGrid = jasmine.createSpy('getGrid').and.returnValue(of({grid: [['a']]}));
+  realTimeUpdates$ = of();
+}
+
+describe('GeneratorPageComponent', () => {
+  let component: GeneratorPageComponent;
+  let fixture: ComponentFixture<GeneratorPageComponent>;
+  let apiService: MockApiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GeneratorPageComponent],
+      providers: [{ provide: ApiService, useClass: MockApiService }]
+    });
+    fixture = TestBed.createComponent(GeneratorPageComponent);
+    component = fixture.componentInstance;
+    apiService = TestBed.inject(ApiService) as unknown as MockApiService;
+  });
+
+  it('should reject invalid bias characters', () => {
+    component.biasChar = '1';
+    component.generateGridWithBias();
+    expect(apiService.getGrid).not.toHaveBeenCalled();
+    expect(component.gridErrorMessage).toBe('Bias character must be a letter a-z.');
+    expect(component.biasInputDisabled).toBeFalse();
+  });
+
+  it('should lowercase and send valid bias character with cooldown', fakeAsync(() => {
+    component.biasChar = 'B';
+    component.generateGridWithBias();
+    expect(apiService.getGrid).toHaveBeenCalledOnceWith('b');
+    expect(component.biasInputDisabled).toBeTrue();
+    tick(4000);
+    expect(component.biasInputDisabled).toBeFalse();
+    expect(component.biasChar).toBe('b');
+  }));
+});

--- a/src/app/generator/generator.component.ts
+++ b/src/app/generator/generator.component.ts
@@ -119,11 +119,19 @@ export class GeneratorPageComponent implements OnInit, OnDestroy {
   generateGridWithBias(): void {
     this.gridErrorMessage = null; // Clear previous error messages for grid
 
+    if (this.biasChar && !/^[a-z]$/i.test(this.biasChar)) {
+      this.gridErrorMessage = 'Bias character must be a letter a-z.';
+      return;
+    }
+
+    if (this.biasChar) {
+      this.biasChar = this.biasChar.toLowerCase();
+    }
+
     this.biasInputDisabled = true;
     clearTimeout(this.biasTimer);
     this.biasTimer = setTimeout(() => {
       this.biasInputDisabled = false;
-      this.biasChar = '';
     }, 4000);
 
     this.apiService.getGrid(this.biasChar || null).subscribe({


### PR DESCRIPTION
## Summary
- validate bias character input and persist value
- add spec for `GeneratorPageComponent`

## Testing
- `npm test` *(fails: Cannot start Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68402d7dca44832f94526b83318b1d32