### PR TITLE
Use API_URL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It consumes the backend API for real-time grid/code updates and payments, and fe
     ```
     - **Default port:** `http://localhost:4200/`
 
-    > **Note:** Make sure your backend API is running at `http://localhost:3000/` or the URL specified in your environment files.
+    > **Note:** Make sure your backend API is running at the URL defined by the `API_URL` environment variable (defaults to `http://localhost:3000`).
 
 3. **Build for production:**
     ```bash
@@ -46,11 +46,9 @@ It consumes the backend API for real-time grid/code updates and payments, and fe
 
 ## 🌐 Backend API
 
-- The Angular app expects the backend API running at:
-    ```
-    http://localhost:3000/
-    ```
-- You can adjust this in `src/environments/environment.ts` if needed.
+- The Angular app expects the backend API URL to come from the `API_URL` environment variable.
+    - If not provided, it falls back to `http://localhost:3000/`.
+- You can override this by setting `API_URL` before running or building the application.
 
 ---
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,9 @@
+// Allow using process.env without adding Node types globally
+declare const process: { env: Record<string, string | undefined> };
+const { API_URL, WS_URL } = process.env;
+
 export const environment = {
   production: false, // Set to true for production build
-  apiUrl: "http://localhost:3000", // API base URL
-  wsUrl: "ws://localhost:3000" // WebSocket server URL
+  apiUrl: API_URL ?? "http://localhost:3000", // API base URL
+  wsUrl: WS_URL ?? "ws://localhost:3000" // WebSocket server URL
 };


### PR DESCRIPTION
## Summary
- reference API_URL environment variable in Angular environment file
- update README with instructions on API_URL usage

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6840343dd36c832fa9af77f3a99806d9