### PR TITLE
Fix env variable read in browser

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,11 @@
 // Allow using process.env without adding Node types globally
-declare const process: { env: Record<string, string | undefined> };
-const { API_URL, WS_URL } = process.env;
+// but guard against the variable not existing in the browser
+declare const process: { env: Record<string, string | undefined> } | undefined;
+
+const API_URL =
+  typeof process !== 'undefined' ? process.env['API_URL'] : undefined;
+const WS_URL =
+  typeof process !== 'undefined' ? process.env['WS_URL'] : undefined;
 
 export const environment = {
   production: false, // Set to true for production build


### PR DESCRIPTION
## Summary
- safeguard references to `process.env` so builds don't error when `process` is undefined

## Testing
- `npm run build`
- `npm run test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68403af92944832f8381cac592de7136