### PR TITLE
Add toast notifications for data operations

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router"; // Import Routes
+import { ToastContainerComponent } from "./toast/toast-container.component";
 
 // Import the page components
 import { GeneratorPageComponent } from "./generator/generator.component";
@@ -23,7 +24,7 @@ export const routes: Routes = [
 @Component({
   selector: "app-root",
   standalone: true,
-  imports: [RouterModule],
+  imports: [RouterModule, ToastContainerComponent],
   template: `
     <div class="main-container">
       <header class="app-header">
@@ -34,6 +35,7 @@ export const routes: Routes = [
         </nav>
       </header>
       <router-outlet></router-outlet>
+      <app-toast-container></app-toast-container>
     </div>
   `,
   styleUrls: ["./app.component.css"]

--- a/src/app/generator/generator.component.spec.ts
+++ b/src/app/generator/generator.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { GeneratorPageComponent } from './generator.component';
 import { ApiService } from '../api.service';
+import { ToastService } from '../toast/toast.service';
 import { of } from 'rxjs';
 
 class MockApiService {
@@ -16,7 +17,10 @@ describe('GeneratorPageComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [GeneratorPageComponent],
-      providers: [{ provide: ApiService, useClass: MockApiService }]
+      providers: [
+        { provide: ApiService, useClass: MockApiService },
+        { provide: ToastService, useValue: { showSuccess: () => {}, showError: () => {} } }
+      ]
     });
     fixture = TestBed.createComponent(GeneratorPageComponent);
     component = fixture.componentInstance;

--- a/src/app/generator/generator.component.ts
+++ b/src/app/generator/generator.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService, GridResponse, Payment, WebSocketMessage } from '../api.service';
+import { ToastService } from '../toast/toast.service';
 import { Subscription } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http'; // Import HttpErrorResponse
 
@@ -78,7 +79,7 @@ export class GeneratorPageComponent implements OnInit, OnDestroy {
 
   private realTimeUpdatesSubscription!: Subscription;
 
-  constructor(private apiService: ApiService) {}
+  constructor(private apiService: ApiService, private toastService: ToastService) {}
 
   ngOnInit(): void {
     // Initial call to generate grid and handle potential server errors on page load
@@ -138,6 +139,7 @@ export class GeneratorPageComponent implements OnInit, OnDestroy {
       next: (response: GridResponse) => {
         console.log('Grid generation request sent via button.');
         this.gridErrorMessage = null; // Clear error on successful response
+        this.toastService.showSuccess('Grid data loaded');
       },
       error: (err: HttpErrorResponse) => {
         console.error('Error generating grid:', err);
@@ -148,12 +150,19 @@ export class GeneratorPageComponent implements OnInit, OnDestroy {
         } else {
           this.gridErrorMessage = 'An unexpected error occurred while generating grid.';
         }
+        this.toastService.showError(this.gridErrorMessage);
       }
     });
   }
 
   addPayment(): void {
     this.paymentErrorMessage = null; // Clear previous error messages for payment
+
+    if (this.grid.length === 0) {
+      this.paymentErrorMessage = 'No grid data available. Cannot save payment.';
+      this.toastService.showError(this.paymentErrorMessage);
+      return;
+    }
 
     // Client-side validation
     if (!this.newPaymentName.trim()) {
@@ -179,6 +188,7 @@ export class GeneratorPageComponent implements OnInit, OnDestroy {
         this.newPaymentName = '';
         this.newPaymentAmount = null;
         this.paymentErrorMessage = null; // Clear error on success
+        this.toastService.showSuccess('Payment added successfully');
       },
       error: (err: HttpErrorResponse) => {
         console.error('Error adding payment:', err);
@@ -189,6 +199,7 @@ export class GeneratorPageComponent implements OnInit, OnDestroy {
         } else {
           this.paymentErrorMessage = 'An unexpected error occurred while adding payment.';
         }
+        this.toastService.showError(this.paymentErrorMessage);
       }
     });
   }

--- a/src/app/payments-list/payments-list.component.ts
+++ b/src/app/payments-list/payments-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import { ApiService, Payment, WebSocketMessage } from '../api.service';
+import { ToastService } from '../toast/toast.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -106,7 +107,7 @@ export class PaymentsListComponent implements OnInit, OnDestroy {
   payments: Payment[] = [];
   private realTimeUpdatesSubscription!: Subscription;
 
-  constructor(private apiService: ApiService) {}
+  constructor(private apiService: ApiService, private toastService: ToastService) {}
 
   ngOnInit(): void {
     // Load initial payments from the API
@@ -140,8 +141,12 @@ export class PaymentsListComponent implements OnInit, OnDestroy {
       next: (payments: Payment[]) => {
         this.payments = payments;
         console.log('Payments loaded:', payments);
+        this.toastService.showSuccess('Payments loaded');
       },
-      error: (err) => console.error('Error loading payments:', err)
+      error: (err) => {
+        console.error('Error loading payments:', err);
+        this.toastService.showError('Error loading payments');
+      }
     });
   }
 }

--- a/src/app/toast/toast-container.component.css
+++ b/src/app/toast/toast-container.component.css
@@ -1,0 +1,20 @@
+.toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.toast {
+  margin-bottom: 10px;
+  padding: 10px 20px;
+  border-radius: 5px;
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+.toast.success {
+  background-color: #28a745;
+}
+.toast.error {
+  background-color: #dc3545;
+}

--- a/src/app/toast/toast-container.component.ts
+++ b/src/app/toast/toast-container.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastService, ToastMessage } from './toast.service';
+
+@Component({
+  selector: 'app-toast-container',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="toast-container">
+      <div *ngFor="let toast of toasts" class="toast" [class.success]="toast.type==='success'" [class.error]="toast.type==='error'">
+        {{ toast.text }}
+      </div>
+    </div>
+  `,
+  styleUrls: ['./toast-container.component.css']
+})
+export class ToastContainerComponent implements OnInit {
+  toasts: ToastMessage[] = [];
+
+  constructor(private toastService: ToastService) {}
+
+  ngOnInit(): void {
+    this.toastService.toast$.subscribe(toast => {
+      this.toasts.push(toast);
+      setTimeout(() => this.toasts.shift(), 3000);
+    });
+  }
+}

--- a/src/app/toast/toast.service.ts
+++ b/src/app/toast/toast.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+export interface ToastMessage {
+  text: string;
+  type: 'success' | 'error';
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private toastSubject = new Subject<ToastMessage>();
+  toast$ = this.toastSubject.asObservable();
+
+  showSuccess(text: string) {
+    this.toastSubject.next({ text, type: 'success' });
+  }
+
+  showError(text: string) {
+    this.toastSubject.next({ text, type: 'error' });
+  }
+}


### PR DESCRIPTION
## Summary
- implement a simple toast service and container
- show toast messages when payments load and when payment operations succeed or fail
- prevent saving payment if grid is empty
- display toast container globally
- adjust unit tests for ToastService injection

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68407b98a7cc832f8d81ae18bb2ed551