### PR TITLE
Add basic component & service tests

### DIFF
--- a/src/app/api.service.spec.ts
+++ b/src/app/api.service.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ApiService } from './api.service';
+import { environment } from '../environments/environment';
+
+describe('ApiService', () => {
+  let service: ApiService;
+  let httpMock: HttpTestingController;
+  const OriginalEventSource = (window as any).EventSource;
+  class MockEventSource {
+    constructor(url: string) {}
+    close() {}
+    onmessage: any;
+    onerror: any;
+  }
+
+  beforeEach(() => {
+    (window as any).EventSource = MockEventSource as any;
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ApiService]
+    });
+    service = TestBed.inject(ApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    (window as any).EventSource = OriginalEventSource;
+  });
+
+  it('should request grid without bias', () => {
+    service.getGrid().subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/grid`);
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should request grid with bias', () => {
+    service.getGrid('a').subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/grid?bias=a`);
+    expect(req.request.method).toBe('GET');
+  });
+});

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  let fixture: ComponentFixture<AppComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, AppComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(AppComponent);
+  });
+
+  it('should create the app', () => {
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+});

--- a/src/app/generator/generator.component.spec.ts
+++ b/src/app/generator/generator.component.spec.ts
@@ -29,7 +29,7 @@ describe('GeneratorPageComponent', () => {
 
   it('should reject invalid bias characters', () => {
     component.biasChar = '1';
-    component.generateGridWithBias();
+    component.onGenerateClick();
     expect(apiService.getGrid).not.toHaveBeenCalled();
     expect(component.gridErrorMessage).toBe('Bias character must be a letter a-z.');
     expect(component.biasInputDisabled).toBeFalse();
@@ -37,7 +37,7 @@ describe('GeneratorPageComponent', () => {
 
   it('should lowercase and send valid bias character with cooldown', fakeAsync(() => {
     component.biasChar = 'B';
-    component.generateGridWithBias();
+    component.onGenerateClick();
     expect(apiService.getGrid).toHaveBeenCalledOnceWith('b');
     expect(component.biasInputDisabled).toBeTrue();
     tick(4000);

--- a/src/app/payments-list/payments-list.component.spec.ts
+++ b/src/app/payments-list/payments-list.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { PaymentsListComponent } from './payments-list.component';
+import { ApiService, Payment } from '../api.service';
+import { ToastService } from '../toast/toast.service';
+
+class MockApiService {
+  getPayments = jasmine.createSpy('getPayments').and.returnValue(of([] as Payment[]));
+  realTimeUpdates$ = of();
+}
+
+describe('PaymentsListComponent', () => {
+  let component: PaymentsListComponent;
+  let fixture: ComponentFixture<PaymentsListComponent>;
+  let apiService: MockApiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PaymentsListComponent],
+      providers: [
+        { provide: ApiService, useClass: MockApiService },
+        { provide: ToastService, useValue: { showSuccess: () => {}, showError: () => {} } }
+      ]
+    });
+    fixture = TestBed.createComponent(PaymentsListComponent);
+    component = fixture.componentInstance;
+    apiService = TestBed.inject(ApiService) as unknown as MockApiService;
+  });
+
+  it('should load payments on init', () => {
+    component.ngOnInit();
+    expect(apiService.getPayments).toHaveBeenCalled();
+  });
+});

--- a/src/app/toast/toast-container.component.spec.ts
+++ b/src/app/toast/toast-container.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { ToastContainerComponent } from './toast-container.component';
+import { ToastService } from './toast.service';
+
+class MockToastService {
+  toast$ = of({ text: 'hello', type: 'success' });
+}
+
+describe('ToastContainerComponent', () => {
+  let component: ToastContainerComponent;
+  let fixture: ComponentFixture<ToastContainerComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ToastContainerComponent],
+      providers: [{ provide: ToastService, useClass: MockToastService }]
+    });
+    fixture = TestBed.createComponent(ToastContainerComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should display toasts from the service', () => {
+    fixture.detectChanges();
+    expect(component.toasts.length).toBe(1);
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.toast')?.textContent).toContain('hello');
+  });
+});

--- a/src/app/toast/toast.service.spec.ts
+++ b/src/app/toast/toast.service.spec.ts
@@ -1,0 +1,21 @@
+import { ToastService } from './toast.service';
+
+describe('ToastService', () => {
+  it('should emit success messages', (done) => {
+    const service = new ToastService();
+    service.toast$.subscribe(msg => {
+      expect(msg).toEqual({ text: 'ok', type: 'success' });
+      done();
+    });
+    service.showSuccess('ok');
+  });
+
+  it('should emit error messages', (done) => {
+    const service = new ToastService();
+    service.toast$.subscribe(msg => {
+      expect(msg).toEqual({ text: 'bad', type: 'error' });
+      done();
+    });
+    service.showError('bad');
+  });
+});


### PR DESCRIPTION
## Summary
- add missing tests for components and services
- fix outdated generator spec method name

## Testing
- `ng test --watch=false --browsers=ChromeHeadless` *(fails: Chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_684120ed2e78832f909501b9bc121310